### PR TITLE
Add support to fetch singletons

### DIFF
--- a/Controller/Direct/Page.php
+++ b/Controller/Direct/Page.php
@@ -1,10 +1,4 @@
 <?php declare(strict_types=1);
-/**
- * Created by PhpStorm.
- * User: jeroen
- * Date: 10-4-19
- * Time: 17:41
- */
 
 namespace Elgentos\PrismicIO\Controller\Direct;
 
@@ -47,6 +41,10 @@ class Page extends Action implements HttpGetActionInterface, HttpPostActionInter
 
         $contentType = $this->getRequest()
             ->getParam('type');
+
+        if ($uid === 'singleton') {
+            return $this->page->renderPageBySingleton($contentType);
+        }
 
         return $this->page->renderPageByUid($uid, $contentType);
     }

--- a/Controller/Direct/Singleton.php
+++ b/Controller/Direct/Singleton.php
@@ -8,7 +8,7 @@ use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\Action;
 
-class Page extends Action implements HttpGetActionInterface, HttpPostActionInterface
+class Singleton extends Action implements HttpGetActionInterface, HttpPostActionInterface
 {
 
     /** @var PageRenderer */
@@ -29,19 +29,9 @@ class Page extends Action implements HttpGetActionInterface, HttpPostActionInter
      */
     public function execute()
     {
-        $id = $this->getRequest()
-                ->getParam('id', '');
-
-        if ($id) {
-            return $this->page->renderPageById($id);
-        }
-
-        $uid = $this->getRequest()
-            ->getParam('uid', '');
-
         $contentType = $this->getRequest()
             ->getParam('type');
 
-        return $this->page->renderPageByUid($uid, $contentType);
+        return $this->page->renderPageBySingleton($contentType);
     }
 }

--- a/Model/Api.php
+++ b/Model/Api.php
@@ -243,6 +243,34 @@ class Api
     }
 
     /**
+     * Get document by uid
+     *
+     * @param string|null $contentType
+     * @param array $options
+     * @return \stdClass|null
+     * @throws ApiNotEnabledException
+     * @throws NoSuchEntityException
+     */
+    public function getSingleton(string $contentType = null, array $options = []): ?\stdClass
+    {
+        $contentType = $contentType ?? $this->getDefaultContentType();
+        $api = $this->create();
+
+        $allowedContentTypes = $api->getData()
+                ->getTypes();
+        if (! isset($allowedContentTypes[$contentType])) {
+            return null;
+        }
+
+        $document = $api->getSingle($contentType, $this->getOptions($options));
+        if ($document || ! $this->isFallbackAllowed()) {
+            return $document;
+        }
+
+        return $api->getSingle($contentType, $this->getOptionsLanguageFallback($options));
+    }
+
+    /**
      * Get document by id
      *
      * @param string $id

--- a/Renderer/Page.php
+++ b/Renderer/Page.php
@@ -60,6 +60,20 @@ class Page
         return $this->createPage($document);
     }
 
+    public function renderPageBySingleton(string $contentType = null): ResultInterface
+    {
+        if (! $this->api->isActive()) {
+            return $this->forwardNoRoute();
+        }
+
+        $document = $this->api->getSingleton($contentType);
+        if (! $document) {
+            return $this->forwardNoRoute();
+        }
+
+        return $this->createPage($document);
+    }
+
     public function renderPageById(string $id): ResultInterface
     {
         if (! $id) {


### PR DESCRIPTION
It is possible to create a "Singleton type" content type in Prismic, instead of a repeatable.

See https://prismic.io/docs/technologies/query-a-single-type-document-php

By passing 'singleton' as UID in the URL, like `prismicio/direct/page/type/homepage/uid/singleton`