### PR TITLE
Replace relative links to base URL in rich texts

### DIFF
--- a/Block/AbstractBlock.php
+++ b/Block/AbstractBlock.php
@@ -57,6 +57,27 @@ abstract class AbstractBlock extends FrameworkAbstractBlock implements BlockInte
     }
 
     /**
+     * Replace the relative URL in Prismic with the actual URL in Magento.
+     *
+     * @param string $context
+     * @return string
+     */
+    protected function replaceRelativeUrl(string $context): string
+    {
+        $baseUrl               = $this->_urlBuilder->getBaseUrl();
+        $findAndReplaceBaseUrl = [
+            'http://{{relative}}/',
+            'https://{{relative}}/',
+            'http://{{relative}}',
+            'https://{{relative}}',
+        ];
+
+        $context = str_replace($findAndReplaceBaseUrl, $baseUrl, $context);
+
+        return $context;
+    }
+
+    /**
      * Fetch document view
      *
      * @return string

--- a/Block/Dom/Link.php
+++ b/Block/Dom/Link.php
@@ -15,15 +15,8 @@ class Link extends AbstractBlock
 {
     public function fetchDocumentView(): string
     {
-        $url = PrismicLink::asUrl($this->getContext(), $this->getLinkResolver());
+        $url = PrismicLink::asUrl($this->getContext(), $this->getLinkResolver()) ?? '';
 
-        $baseUrl = $this->_urlBuilder->getBaseUrl();
-        $findAndReplaceBaseUrl = [
-            'http://{{relative}}',
-            'https://{{relative}}',
-        ];
-
-        $url = str_replace($findAndReplaceBaseUrl, $baseUrl, $url);
-        return $this->escapeUrl($url);
+        return $this->escapeUrl($this->replaceRelativeUrl($url));
     }
 }

--- a/Block/Dom/RichText.php
+++ b/Block/Dom/RichText.php
@@ -35,6 +35,12 @@ class RichText extends AbstractBlock
 
     public function fetchDocumentView(): string
     {
-        return PrismicRichText::asHtml($this->getContext(), $this->getLinkResolver(), [$this->htmlSerializer, 'serialize']);
+        $html = PrismicRichText::asHtml(
+            $this->getContext(),
+            $this->getLinkResolver(),
+            [$this->htmlSerializer, 'serialize']
+        );
+
+        return $this->replaceRelativeUrl($html);
     }
 }


### PR DESCRIPTION
The relative links used in Prismic `https://{{relative}}` is now
replaced to the current store's base URL within rich texts. This
was already the case for relative links in the "link" element, but
this has been copied to rich texts as well.

Also the double slash after the base URL is solved. It is common
to write a link in Prismic as `https://{{relative}}/something` which
is changed to `https://www.mydomain.com//something`, adding an
unwanted extra slash, because the base URL already contains a trailing
slash.