### PR TITLE
Solve return null value issue

### DIFF
--- a/Block/Dom/Link.php
+++ b/Block/Dom/Link.php
@@ -21,6 +21,10 @@ class Link extends AbstractBlock
         }
         $url = PrismicLink::asUrl($context, $this->getLinkResolver() ?? '');
 
+        if(!$url) {
+            return '';
+        }
+
         return $this->escapeUrl($this->replaceRelativeUrl($url));
     }
 }


### PR DESCRIPTION
.CRITICAL: TypeError: Argument 1 passed to Elgentos\PrismicIO\Block\AbstractBlock::replaceRelativeUrl() must be of the type string, null given