### PR TITLE
Add pageArguments

### DIFF
--- a/Renderer/Page.php
+++ b/Renderer/Page.php
@@ -116,11 +116,11 @@ class Page
         return $resultRedirect;
     }
 
-    private function createPage(\stdClass $document): ResultInterface
+    public function createPage(\stdClass $document, $pageArguments = []): ResultInterface
     {
         $this->currentDocument->setDocument($document);
 
-        $page = $this->pageFactory->create();
+        $page = $this->pageFactory->create(false, $pageArguments);
         $page->addHandle([
             'prismicio_default',
             'prismicio_by_type_' . $document->type,


### PR DESCRIPTION
We need this to programatically render out Prismic documents so we can index them in a search engine like Elasticsearch.

See the line that starts with `$page`;

```php
    /**
     * @throws NoSuchEntityException
     * @throws ApiNotEnabledException|Exception
     */
    private function getIndexableTextFromDocument(stdClass $document, StoreInterface $store): string
    {
        return $this->appState->emulateAreaCode('frontend', function () use ($document, $store) {
            $this->emulation->startEnvironmentEmulation($store->getId());

            // Create Prismic Document object
            $prismicPage     = $this->prismicPageFactory->create();
            /** @var \Magento\Framework\View\Result\Page $page */
            $page            = $prismicPage->createPage($document, ['isIsolated' => true]);

            // Remove blocks from layout
            $layout          = $page->getLayout();
            array_map(function ($blockName) use ($layout) {
                    $layout->unsetElement($blockName);
                }, array_filter(
                    array_map('trim',
                        explode(
                            PHP_EOL,
                            $this->extensionConfiguration->getConfigValue('block_blacklist')
                        )
                    )
                )
            );

            // Generate response HTML
            /** @var Http $response */
            $response = $this->responseFactory->create();
            $page->renderResult($response);
            $content = $response->getContent();
            $this->emulation->stopEnvironmentEmulation();

            // Extract text from HTML
            $html = new Html2Text($content);
            return $html->getText();
        });
    }
```