### PR TITLE
Get all documents for the Magento Sitemap

### DIFF
--- a/Model/ItemProvider/PrismicPages.php
+++ b/Model/ItemProvider/PrismicPages.php
@@ -73,7 +73,17 @@ class PrismicPages implements ItemProviderInterface
                 ['lang' => $this->configuration->getContentLanguage($store)]
             );
 
-            $this->addDocumentsToSitemap($localeDocuments->results, $store);
+            foreach (range(1, $localeDocuments->total_pages) as $page) {
+                $documents = $api->query(
+                    [Predicates::at('document.type', $sitemapContentType)],
+                    [
+                        'lang' => $this->configuration->getContentLanguage($store),
+                        'page' => $page
+                    ]
+                );
+
+                $this->addDocumentsToSitemap($documents->results, $store);
+            }
         }
 
         return $this->sitemapItems;


### PR DESCRIPTION
The current function for adding items to the sitemap retrieves only the first 20 documents. Added a few lines of code to loop trough the pages to retrieve all the documents. 