### PR TITLE
Enable showInStore and showInWebsite for sitemap setting

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -88,7 +88,7 @@
                 </field>
             </group>
 
-            <group id="sitemap" translate="true" showInDefault="1">
+            <group id="sitemap" translate="true" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Sitemap</label>
                 <field id="content_types" showInDefault="1" showInWebsite="1" showInStore="1" translate="label" type="multiselect">
                     <label>Include Content types in sitemap</label>


### PR DESCRIPTION
The configuration field content_types is only visible in default settings. When there a different stores with each store has his own content type the sitemap contains all the content types. 