### PR TITLE
Updated Link to also work with strings

### DIFF
--- a/Block/Dom/Link.php
+++ b/Block/Dom/Link.php
@@ -17,8 +17,9 @@ class Link extends AbstractBlock
     {
         $context = $this->getContext();
         if (!isset($context->link_type)) {
-            $context->link_type = 'Document';
+            return $this->escapeUrl($this->replaceRelativeUrl($url));
         }
+        
         $url = PrismicLink::asUrl($context, $this->getLinkResolver() ?? '');
 
         if(!$url) {

--- a/Block/Dom/Link.php
+++ b/Block/Dom/Link.php
@@ -17,7 +17,7 @@ class Link extends AbstractBlock
     {
         $context = $this->getContext();
         if (!isset($context->link_type)) {
-            return $this->escapeUrl($this->replaceRelativeUrl($url));
+            return $this->escapeUrl($this->replaceRelativeUrl($context));
         }
         
         $url = PrismicLink::asUrl($context, $this->getLinkResolver() ?? '');


### PR DESCRIPTION
When a link is for example a `tel:+3112345678` it will replace the link type, but this breaks because `tel:` does not have a link type.

The solution is to return the `$context` directly because it will be a string instead of an object containing a url and a type.