### PR TITLE
Fix webhooks (route protection and cache invalidation on Unpublish)

### DIFF
--- a/Controller/Webhook/Cache.php
+++ b/Controller/Webhook/Cache.php
@@ -82,7 +82,7 @@ class Cache implements HttpPostActionInterface, CsrfAwareActionInterface
         $api = $this->apiFactory->create();
         foreach ($documentIds as $documentId) {
             $document = $api->getByID($documentId);
-            if (in_array($document->type, $cacheFlushDocumentTypes)) {
+            if ($document && in_array($document->type, $cacheFlushDocumentTypes)) {
                 $this->typeList->cleanType(Type::TYPE_IDENTIFIER);
 
                 break;

--- a/Controller/Webhook/Url.php
+++ b/Controller/Webhook/Url.php
@@ -72,10 +72,6 @@ class Url implements HttpPostActionInterface, CsrfAwareActionInterface
 
     public function execute(): ?ResultInterface
     {
-        if (!$this->protectRoute()) {
-            return null;
-        }
-
         $result = $this->resultFactory->create(ResultFactory::TYPE_JSON);
 
         $payload = json_decode($this->request->getContent() ?? '', true);
@@ -83,6 +79,10 @@ class Url implements HttpPostActionInterface, CsrfAwareActionInterface
             return $result->setData([
                 'success' => true
             ]);
+        }
+
+        if (!$this->protectRoute($payload)) {
+            return null;
         }
 
         $store = $this->storeManager->getStore();
@@ -165,12 +165,14 @@ class Url implements HttpPostActionInterface, CsrfAwareActionInterface
         return true;
     }
 
-    private function protectRoute()
+    private function protectRoute(array $payload): bool
     {
         $accessToken = $this->configuration->getWebhookSecret($this->storeManager->getStore());
 
-        if ($this->request->getParam('secret') === $accessToken) {
+        if ($payload['secret'] ?? '' === $accessToken) {
             return true;
         }
+
+        return false;
     }
 }

--- a/Controller/Webhook/Url.php
+++ b/Controller/Webhook/Url.php
@@ -106,6 +106,9 @@ class Url implements HttpPostActionInterface, CsrfAwareActionInterface
         $api = $this->apiFactory->create();
         foreach ($documentIds as $documentId) {
             $document = $api->getByID($documentId);
+            if (!$document) {
+                continue;
+            }
 
             $urlRewrite = $this->findUrlRewrite($document, $store);
 


### PR DESCRIPTION
This fixes the `Invalid return type`  500 error on the webhooks;

```
Exception #0 (InvalidArgumentException): Invalid return type                                                                                                                                                       
<pre>#1 Magento\Framework\App\Http\Interceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]                                                                              
#2 Magento\Framework\App\Http\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/justbetter/magento2-sentry/Plugin/GlobalExceptionCatcher.php:57]                                           
#3 JustBetter\Sentry\Plugin\GlobalExceptionCatcher->aroundLaunch() called at [vendor/magento/framework/Interception/Interceptor.php:135]                                                                           
#4 Magento\Framework\App\Http\Interceptor->Magento\Framework\Interception\{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]                                                        
#5 Magento\Framework\App\Http\Interceptor->___callPlugins() called at [generated/code/Magento/Framework/App/Http/Interceptor.php:23]                                                                               
#6 Magento\Framework\App\Http\Interceptor->launch() called at [vendor/magento/framework/App/Bootstrap.php:264]                                                                                                     
#7 Magento\Framework\App\Bootstrap->run() called at [pub/index.php:30]                                                                                                                                             
</pre> 
```

You can test this fix by checking out this branch (or applying the patch) and hitting the webhook locally. Create a `payload.json`:

```json
{
  "secret": "secretgoeshere"
}
```

Then hit the controller;

```sh
curl --insecure -XPOST  -H 'Content-Type: application/json' -d @payload.json https://yourlocalurl.localhost/prismicio/webhook/cache
```

This should then return `{"success":true}`.

