### PR TITLE
Document links on index pages don't work

### DIFF
--- a/Block/Dom/Link.php
+++ b/Block/Dom/Link.php
@@ -17,7 +17,7 @@ class Link extends AbstractBlock
     {
         $context = $this->getContext();
         if (!isset($context->link_type)) {
-            return $this->escapeUrl($this->replaceRelativeUrl($context));
+            $context->link_type = 'Document';
         }
         
         $url = PrismicLink::asUrl($context, $this->getLinkResolver() ?? '');


### PR DESCRIPTION
Without this change the links for individual items on index pages won't work, like here `news.link`: 
![image](https://user-images.githubusercontent.com/2726055/218486122-05140cad-001d-4ca6-b5cb-b7a01ae3f578.png)

The `resolveRouteUrl` function in `LinkResolver.php` does not have a contentype, so it won't resolve the link with the contenttype attached in front of the uid.  