### PR TITLE
Use correct id field in adminhtml grid

### DIFF
--- a/view/adminhtml/ui_component/prismicio_route_listing.xml
+++ b/view/adminhtml/ui_component/prismicio_route_listing.xml
@@ -22,7 +22,7 @@
     <dataSource name="prismicio_route_listing_data_source" component="Magento_Ui/js/grid/provider">
         <settings>
             <storageConfig>
-                <param name="indexField" xsi:type="string">block_id</param>
+                <param name="indexField" xsi:type="string">route_id</param>
             </storageConfig>
             <updateUrl path="mui/index/render"/>
         </settings>


### PR DESCRIPTION
This fixes unexpected behaviour in the admin grid when changing the sort field