### PR TITLE
added metadata block for Keywords

### DIFF
--- a/Block/Layout/Metadata/Keywords.php
+++ b/Block/Layout/Metadata/Keywords.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Elgentos\PrismicIO\Block\Layout\Metadata;
+
+use Elgentos\PrismicIO\Block\AbstractTemplate;
+
+class Keywords extends AbstractTemplate
+{
+    protected function _prepareLayout(): Keywords|static
+    {
+        if (!$this->getDocumentResolver()->hasDocument()) {
+            return $this;
+        }
+
+        $this->pageConfig->setMetadata('keywords', $this->getChildHtml());
+
+        return $this;
+    }
+}


### PR DESCRIPTION
In addition to description and title meta tags we would also like to be able to use the 'keywords' meta tag for our client.