### PR TITLE
Prevent the sitemap from containing urls of other stores

### DIFF
--- a/Model/ItemProvider/PrismicPages.php
+++ b/Model/ItemProvider/PrismicPages.php
@@ -64,7 +64,7 @@ class PrismicPages implements ItemProviderInterface
     {
         $store = $this->storeManager->getStore($storeId);
 
-        if($store?->isUseStoreInUrl()) {
+        if ($store?->isUseStoreInUrl()) {
             $this->sitemapItems = [];
         }
 

--- a/Model/ItemProvider/PrismicPages.php
+++ b/Model/ItemProvider/PrismicPages.php
@@ -64,6 +64,10 @@ class PrismicPages implements ItemProviderInterface
     {
         $store = $this->storeManager->getStore($storeId);
 
+        if($store?->isUseStoreInUrl()) {
+            $this->sitemapItems = [];
+        }
+
         $sitemapContentTypes = $this->getSitemapContentTypes($store);
         $api = $this->apiFactory->create();
 


### PR DESCRIPTION
With the cron job `sitemap_generate`, the list of URLs is not cleared, resulting in URLs from other shops appearing in the sitemap where they don't belong.