### PR TITLE
Implement config value to allow disabling of exceptions

### DIFF
--- a/src/Api/ConfigurationInterface.php
+++ b/src/Api/ConfigurationInterface.php
@@ -21,6 +21,7 @@ interface ConfigurationInterface
         XML_PATH_CONTENT_FETCHLINKS                 = 'prismicio/content/fetchlinks',
         XML_PATH_CONTENT_CONTENT_TYPE               = 'prismicio/content/content_type',
         XML_PATH_CONTENT_ALLOW_DEBUG                = 'prismicio/content/allow_debug',
+        XML_PATH_CONTENT_THROW_EXCEPTIONS           = 'prismicio/content/throw_exceptions',
         XML_PATH_CONTENT_ALLOW_PREVIEW              = 'prismicio/content/allow_preview',
 
         XML_PATH_INTEGRATION_ACCESS_TOKEN           = 'prismicio/integration_fields/access_token',
@@ -52,6 +53,7 @@ interface ConfigurationInterface
     public function getContentType(StoreInterface $store): string;
 
     public function allowDebugInFrontend(StoreInterface $store): bool;
+    public function allowExceptions(StoreInterface $store): bool;
     public function allowPreviewInFrontend(StoreInterface $store): bool;
 
     public function getIntegrationFieldsAccessToken(StoreInterface $store): string;

--- a/src/Block/Exception/ExceptionLogger.php
+++ b/src/Block/Exception/ExceptionLogger.php
@@ -38,8 +38,12 @@ class ExceptionLogger
             return;
         }
 
-        // Only throw the exception in developer mode
-        throw $exception;
+        if (!$this->configuration->allowExceptions($store)) {
+            return;
+        }
+
+         // Only throw the exception in developer mode and when opted in for
+         throw $exception;
     }
 
     /**

--- a/src/Block/Exception/ExceptionLogger.php
+++ b/src/Block/Exception/ExceptionLogger.php
@@ -34,9 +34,6 @@ class ExceptionLogger
         );
 
         $store = $this->storeManager->getStore();
-        if (! $this->configuration->allowDebugInFrontend($store)) {
-            return;
-        }
 
         if (!$this->configuration->allowExceptions($store)) {
             return;

--- a/src/Model/Configuration.php
+++ b/src/Model/Configuration.php
@@ -116,6 +116,19 @@ class Configuration implements ConfigurationInterface
             ) ?? '');
     }
 
+    public function allowExceptions(StoreInterface $store): bool
+    {
+        if ($this-state->getMode() !== $this->state::MODE_DEVELOPER) {
+            return false;
+        }
+
+        return (bool) ($this->config->getValue(
+            self::XML_PATH_CONTENT_THROW_EXCEPTIONS,
+            ScopeInterface::SCOPE_STORE,
+            $store
+        ) ?? '');
+    }
+
     public function allowPreviewInFrontend(StoreInterface $store): bool
     {
         return (bool)($this->config->getValue(

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -74,6 +74,11 @@
                     <comment><![CDATA[Allow displaying Elgentos\Prismicio\Block\Debug in frontend, this only works if developer mode is also enabled</code>]]></comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="throw_exceptions" showInDefault="1" showInWebsite="1" showInStore="1" translate="label comment" type="select">
+                    <label>Throw exceptions for layout errors</label>
+                    <comment><![CDATA[Allow throwing of exceptions on frontend, this only works if developer mode is also enabled. If disabled, exceptions are logged in debug.log</code>]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <field id="allow_preview" showInDefault="1" showInWebsite="1" showInStore="1" translate="label comment" type="select">
                     <label>Preview</label>
                     <comment><![CDATA[Allow using preview features from Prismic</code>]]></comment>

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -24,6 +24,7 @@
                 <content_type />
                 <fetchlinks />
                 <allow_debug>1</allow_debug>
+                <throw_exceptions>0</throw_exceptions>
                 <allow_preview />
             </content>
             <integration_fields>


### PR DESCRIPTION
Implemented a config value for throwing exceptions and put default to 0.

This allows the frontend to continue to function when prismic slices aren't entirely correct.
When the exceptions are suppressed they are still logged to debug.log

Also only allows this value to work if the developer mode is enabled.