### PR TITLE
Check if document type is allowed before creating url rewrite

### DIFF
--- a/src/Controller/Webhook/Url.php
+++ b/src/Controller/Webhook/Url.php
@@ -115,6 +115,10 @@ class Url implements HttpPostActionInterface, CsrfAwareActionInterface
                 continue;
             }
 
+            if (!in_array($document->type, $urlRewriteDocumentTypes)) {
+                continue;
+            }
+
             $currentStore = $this->getStoreView->getCurrentStoreView($document);
 
             if (!$currentStore) {


### PR DESCRIPTION
Url rewrites are being created even when the type has not been allowed in the admin. Elgentos\PrismicIO\Controller\Webhook\Url is checking if any types have been allowed, but there isn't any support for checking if a document is in the allowed list of types before creating the url rewrite.

This means that url rewrites are being created for types that are not pages and this can cause clashes with urls on Magento.