### PR TITLE
Content type is not required

### DIFF
--- a/src/Model/Configuration.php
+++ b/src/Model/Configuration.php
@@ -258,10 +258,10 @@ class Configuration implements ConfigurationInterface
         return $configValue ? explode(',', $configValue) : [];
     }
 
-    public function isWhitelistContentTypeWhitelisted(StoreInterface $store, string $contentType): bool
+    public function isWhitelistContentTypeWhitelisted(StoreInterface $store, ?string $contentType): bool
     {
         // safety mechanism for when enabled but no whitelist items are present
-        if (!$this->isWhitelistEnabled($store) || empty($this->getContentTypes($store))) {
+        if ($contentType === null || !$this->isWhitelistEnabled($store) || empty($this->getContentTypes($store))) {
             return true;
         }
 


### PR DESCRIPTION
When the content type is not provided in the URL, the default content type is used. A modification has been made to ensure this also works correctly in the whitelist check, preventing any errors from occurring.