### PR TITLE
Adjust exception handling and allow excluded slices to be defined.

### DIFF
--- a/src/Block/Slices.php
+++ b/src/Block/Slices.php
@@ -11,13 +11,23 @@ class Slices extends Group
     public function fetchItem(\stdClass $slice, $key = null): string
     {
         $sliceTypeBlock = $this->getSliceTypeBlock($slice->slice_type);
-        if (null === $sliceTypeBlock) {
-            SliceNotFoundException::throwException($this, [
+        $excludedSlicesFromRender = $this->getData('excluded_slices');
+
+        if (
+            null === $sliceTypeBlock &&
+            !in_array($slice->slice_type, $excludedSlicesFromRender ?? [])
+        ) {
+        
+            SliceNotFoundException::throwException(
+                $this,
+                [
                 'slice_type' => $slice->slice_type,
-            ]);
+                ]
+            );
+
             return '';
         }
-
+        
         $sliceTypeBlock->setDocument($slice);
         return $sliceTypeBlock->toHtml();
     }


### PR DESCRIPTION
Since I'm working with Prismic again, I'm taking a closer look to see if we can better handle exceptions to prevent slices defined in Prismic from not being rendered in Magento.

Currently, we encounter exceptions when a slice exists in Prismic but is not rendered in the layout. This results in the infamous "SliceNotFound" exception, which we often disable in production environments.

What I want to achieve now is being able to define a slice area in two places while maintaining flexibility in deciding which slice I want to display where. However, the "SliceNotFound" exception would also come up in this scenario because I've defined a slice area where not all slices are meant to be transferred. So, this is a no-go.

My proposal is as follows: I suggest adding an excluded_slices array to the Elgentos\PrismicIO\Block\Slices block. In this array, you can specify, "I don't want slice-X and slice-Y to be displayed here." Indirectly, this would mean you're saying, "I know these slices won't be displayed."

With this approach, we can handle slices more intentionally.

Here’s an example structure:
```
<block name="prismic.blog_page.before_slices" class="Elgentos\PrismicIO\Block\Slices" template="data.slices">
    <arguments>
        <argument name="excluded_slices" xsi:type="array">
            <item name="rich_text_area" xsi:type="string">rich_text_area</item>
            <item name="blog_button" xsi:type="string">blog_button</item>
        </argument>
    </arguments>
</block>
```
Note: If you don't define excluded_slices, the exception will still be thrown. However, based on the exception, you can define an excluded_slices array, which could become a task to clean up later on.


Also this is not yet ready.
Simply an example.