### PR TITLE
added setting to backend configuration for the api page size

### DIFF
--- a/src/Api/ConfigurationInterface.php
+++ b/src/Api/ConfigurationInterface.php
@@ -12,6 +12,7 @@ interface ConfigurationInterface
         XML_PATH_API_ENABLED                        = 'prismicio/general/enabled',
         XML_PATH_API_ENDPOINT                       = 'prismicio/general/enpoint',
         XML_PATH_API_SECRET                         = 'prismicio/general/token',
+        XML_PATH_API_PAGE_SIZE                      = 'prismicio/general/page_size',
 
         XML_PATH_MULTI_REPO_ENABLED                 = 'prismicio/multirepo/enabled',
         XML_PATH_MULTI_REPO_FIELD                   = 'prismicio/multirepo/field',
@@ -42,6 +43,8 @@ interface ConfigurationInterface
     public function getApiEndpoint(StoreInterface $store): string;
 
     public function getApiSecret(StoreInterface $store): string;
+
+    public function getApiPageSize(StoreInterface $store): int;
 
     public function getMultiRepoEnabled(StoreInterface $store): bool;
 

--- a/src/Model/Configuration.php
+++ b/src/Model/Configuration.php
@@ -53,6 +53,15 @@ class Configuration implements ConfigurationInterface
         );
     }
 
+    public function getApiPageSize(StoreInterface $store): int
+    {
+        return (int)($this->config->getValue(
+            self::XML_PATH_API_PAGE_SIZE,
+            ScopeInterface::SCOPE_STORE,
+            $store,
+        ) ?? 20);
+    }
+
     public function getContentLanguage(StoreInterface $store): string
     {
         return (string)($this->config->getValue(

--- a/src/Model/ItemProvider/PrismicPages.php
+++ b/src/Model/ItemProvider/PrismicPages.php
@@ -23,7 +23,7 @@ class PrismicPages implements ItemProviderInterface
      * @var SitemapItemFactory
      */
     protected $itemFactory;
-    
+
     /**
      * @var Api
      */
@@ -79,7 +79,10 @@ class PrismicPages implements ItemProviderInterface
         foreach ($sitemapContentTypes as $sitemapContentType) {
             $localeDocuments = $api->query(
                 [Predicates::at('document.type', $sitemapContentType)],
-                ['lang' => $this->configuration->getContentLanguage($store)]
+                [
+                    'lang' => $this->configuration->getContentLanguage($store),
+                    'pageSize' => $this->configuration->getApiPageSize($store)
+                ]
             );
 
             foreach (range(1, $localeDocuments->total_pages) as $page) {
@@ -87,7 +90,8 @@ class PrismicPages implements ItemProviderInterface
                     [Predicates::at('document.type', $sitemapContentType)],
                     [
                         'lang' => $this->configuration->getContentLanguage($store),
-                        'page' => $page
+                        'page' => $page,
+                        'pageSize' => $this->configuration->getApiPageSize($store)
                     ]
                 );
 

--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -29,6 +29,13 @@
                         <field id="enabled">1</field>
                     </depends>
                 </field>
+                <field id="page_size" showInDefault="1" showInWebsite="1" showInStore="1" translate="label">
+                    <label>API page size</label>
+                    <depends>
+                        <field id="enabled">1</field>
+                    </depends>
+                    <comment>How many documents to fetch per page, default is 20, maximum is 100</comment>
+                </field>
             </group>
 
             <group id="multirepo" translate="label" showInDefault="1" showInWebsite="1" showInStore="1">

--- a/src/etc/config.xml
+++ b/src/etc/config.xml
@@ -13,6 +13,7 @@
                 <multirepo>0</multirepo>
                 <enpoint />
                 <token />
+                <page_size>20</page_size>
             </general>
             <multirepo>
                 <enabled>0</enabled>


### PR DESCRIPTION
Made it possible to adjust the page size for the document API calls. This way we can adjust the amount of data returned from the Prismic API.
