### PR TITLE
Add sitemap documents filter hook

### DIFF
--- a/src/Model/ItemProvider/PrismicPages.php
+++ b/src/Model/ItemProvider/PrismicPages.php
@@ -65,6 +65,11 @@ class PrismicPages implements ItemProviderInterface
         $this->configReader = $configReader;
     }
 
+    public function filterDocumentsForSitemap(array $documents): array
+    {
+        return $documents;
+    }
+
     public function getItems($storeId): array
     {
         $store = $this->storeManager->getStore($storeId);
@@ -95,7 +100,10 @@ class PrismicPages implements ItemProviderInterface
                     ]
                 );
 
-                $this->addDocumentsToSitemap($documents->results, $store);
+                $this->addDocumentsToSitemap(
+                    $this->filterDocumentsForSitemap($documents->results),
+                    $store
+                );
             }
         }
 


### PR DESCRIPTION
Adds a small extensibility hook to filter Prismic documents before they are added to the sitemap. Default behavior stays the same, but integrators can now exclude documents (for example those marked NOINDEX) via a plugin.