### PR TITLE
Fix integration products pagination and results_size

### DIFF
--- a/src/Controller/Integration/Products.php
+++ b/src/Controller/Integration/Products.php
@@ -90,9 +90,12 @@ class Products implements HttpGetActionInterface
         $productCollection->addAttributeToFilter('visibility', $visibility)
             ->addAttributeToSelect($attributes)
             ->addAttributeToSort('updated_at', 'DESC');
+        $productCollection->getSelect()->order('e.entity_id DESC');
 
-        $productCollection->setPageSize(50);
-        $productCollection->setCurPage((int)$this->request->getParam('page', 1));
+        $pageSize = 50;
+        $page = max(1, (int)$this->request->getParam('page', 1));
+        $resultsSize = $productCollection->getSize();
+        $productCollection->getSelect()->limit($pageSize, ($page - 1) * $pageSize);
 
         $mediaUrl = $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
         $results = array_values(array_map(function ($product) use ($mediaUrl) {
@@ -108,7 +111,7 @@ class Products implements HttpGetActionInterface
 
         $jsonResult = $this->jsonFactory->create();
         $jsonResult->setData([
-            'results_size' => $productCollection->getSize(),
+            'results_size' => $resultsSize,
             'results' => $results
         ]);
 


### PR DESCRIPTION
The integration products feed reported the wrong results_size and returned inconsistent pages:

- results_size returned the loaded page count (e.g. 50) instead of the grand total, because getSize() was called after the collection was loaded with a page size. Per the Prismic integration spec results_size must be the total number of items so Prismic knows how many pages to request; with a too-low value Prismic only fetched the first page.
- setPageSize()/setCurPage() clamp the current page to the last page via getSize() during load, which (combined with the above) wrapped out-of-range pages back to page 1, resending the first page instead of an empty result.
- Sorting only by updated_at is not deterministic across the separate paged requests when many products share the same timestamp (common after a bulk import or reindex), so products overlapped or were skipped between pages.

Take the total size before applying the limit, paginate with a manual limit/offset, and add entity_id as a stable secondary sort.